### PR TITLE
Added support for Environments in GTM

### DIFF
--- a/src/AnalyticsTracker/TagManager.cs
+++ b/src/AnalyticsTracker/TagManager.cs
@@ -5,11 +5,13 @@ namespace Vertica.AnalyticsTracker
 	public class TagManager
 	{
 
-		public static IHtmlString Render(string account = "GTM-XXXX", string dataLayerName = "dataLayer")
+		public static IHtmlString Render(string account = "GTM-XXXX", string dataLayerName = "dataLayer", string environmentAuth = null, string environmentPreview = null)
 		{
 			var current = Current;
 			current.SetAccount(account);
 			current.SetDataLayerName(dataLayerName);
+			current.SetEnvironmentAuth(environmentAuth);
+			current.SetEnvironmentPreview(environmentPreview);
 
 			return new HtmlString(current.Render());
 		}

--- a/src/AnalyticsTracker/TagTracker.cs
+++ b/src/AnalyticsTracker/TagTracker.cs
@@ -8,6 +8,8 @@ namespace Vertica.AnalyticsTracker
         private string _account;
         private string _dataLayerName;
         private readonly List<MessageBase> _messages;
+        private string _environmentAuth;
+        private string _environmentPreview;
 
         public TagTracker()
         {
@@ -34,6 +36,9 @@ namespace Vertica.AnalyticsTracker
             var sb = new StringBuilder();
             RenderDataLayer(sb);
 
+            var environmentQueryParameter = _environmentAuth != null && _environmentPreview != null
+                ? string.Format("+'&gtm_auth={0}&gtm_preview={1}'", _environmentAuth, _environmentPreview)
+                : "";
 
             sb.AppendFormat(@"<!-- Google Tag Manager -->
 <noscript><iframe src='//www.googletagmanager.com/ns.html?id={0}' height='0' width='0' style='display:none;visibility:hidden'></iframe></noscript>
@@ -43,11 +48,11 @@ w[l]=w[l]||[];
 w[l].push({{'gtm.start': new Date().getTime(),event:'gtm.js'}});
 var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';
 j.async=true;
-j.src='//www.googletagmanager.com/gtm.js?id='+i+dl;
+j.src='//www.googletagmanager.com/gtm.js?id='+i+dl{2};
 f.parentNode.insertBefore(j,f);
 }})(window,document,'script','{1}','{0}');
 </script>
-<!-- End Google Tag Manager -->", _account, _dataLayerName);
+<!-- End Google Tag Manager -->", _account, _dataLayerName, environmentQueryParameter);
 
             return sb.ToString();
         }
@@ -75,6 +80,16 @@ f.parentNode.insertBefore(j,f);
             {
                 sb.AppendLine(message.RenderMessage(_dataLayerName));
             }
+        }
+
+        public void SetEnvironmentAuth(string environmentAuth)
+        {
+            _environmentAuth = environmentAuth;
+        }
+
+        public void SetEnvironmentPreview(string environmentPreview)
+        {
+            _environmentPreview = environmentPreview;
         }
     }
 }


### PR DESCRIPTION
I have added gtm_auth and gtm_preview, but i did not include gtm_cookies_win since this seemed unnecessary and furthermore i could not find any documentation for it.

Original snippet for an custom environment:

<!-- Google Tag Manager -->

<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-xxxxx&gtm_auth=xxxxx&gtm_preview=xxxxx&gtm_cookies_win=x"
height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
'//www.googletagmanager.com/gtm.js?id='+i+dl+'&gtm_auth=xxxxx&gtm_preview=xxxxx&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);
})(window,document,'script','dataLayer','GTM-xxxxx');</script>

<!-- End Google Tag Manager -->
